### PR TITLE
Add mention notification support in Comment component. Update mention handling to ensure notifications are sent for unique mentions.

### DIFF
--- a/src/Livewire/Comment.php
+++ b/src/Livewire/Comment.php
@@ -409,7 +409,9 @@ class Comment extends Component implements HasActions, HasForms
             }
         }
 
-        $mentions = collect($mentions)->unique();
+        $mentions = collect($mentions)->unique()->all();
+
+        $this->sendMentionNotification($mentions);
     }
 
     private function sendMentionNotification(array $mentions): void


### PR DESCRIPTION
This pull request includes a small change to the `src/Livewire/Comment.php` file. The change ensures that the `mentionUser` function now calls `sendMentionNotification` with the unique mentions collected. 

Changes in `mentionUser` function:

* [`src/Livewire/Comment.php`](diffhunk://#diff-24beab32dc255e8a680c509008d1069d97987941c7f18e6d48885b923eecb027L412-R414): Modified the `mentionUser` function to call `sendMentionNotification` with the unique mentions collected.